### PR TITLE
 Fixed TypeError when exporting flows with Hotspot overrides

### DIFF
--- a/src/command-export-html.js
+++ b/src/command-export-html.js
@@ -195,9 +195,11 @@ export default function(context) {
         if (isFixed) {
           dup.setIsFixedToViewport(true);
         }
-        dup.setResizingConstraint(resizingConstraint);
-        flattenSymbolInstances_(dup);
-        dupList.push(dup);
+        if (dup != null) {
+          dup.setResizingConstraint(resizingConstraint);
+          flattenSymbolInstances_(dup);
+          dupList.push(dup);
+        }
       }
     };
 


### PR DESCRIPTION
When exporting a flow with Hotspot overrides (aka hotspots defined in a symbol with targets being defined in overrides) a TypeError (null is not an object) occured.